### PR TITLE
feat(tools): Added custom QA check for html tag display settings

### DIFF
--- a/__fixtures/validate-if-numbered-tags-exist-test-objects.js
+++ b/__fixtures/validate-if-numbered-tags-exist-test-objects.js
@@ -1,0 +1,36 @@
+const tests = [
+  {
+    name: 'should pass when source and translation do not contain any <0> tags',
+    crowdin: {
+      source: `The <code>p</code> contains paragraph text.`,
+      translation: `El <code>p</code> contiene texto de párrafo.`
+    },
+      result: {
+      success: true
+    }
+  },
+  {
+    name: 'should fail when source contains one or more <0> tags',
+    crowdin: {
+      source: `The <0>p</0> contains paragraph text.`,
+      translation: `El <code>p</code> contiene texto de párrafo.`
+    },
+    result: {
+      success: false,
+      message: 'Under Editor Settings, make sure you have selected "Show" for the "HTML tags displaying" setting. You may currently have it set to "Auto".'
+    }
+  },
+  {
+    name: 'should fail when translation contains one or more <0> tags',
+    crowdin: {
+      source: `The <code>p</code> contains paragraph text.`,
+      translation: `El <0>p</0> contiene texto de párrafo.`
+    },
+    result: {
+      success: false,
+      message: 'Under Editor Settings, make sure you have selected "Show" for the "HTML tags displaying" setting. You may currently have it set to "Auto".'
+    }
+  }
+];
+
+module.exports = tests;

--- a/__fixtures/validate-inline-code-blocks-test-objects.js
+++ b/__fixtures/validate-inline-code-blocks-test-objects.js
@@ -82,8 +82,7 @@ const tests = [
     result: {
       success: true
     }
-  }
-,  
+  } 
 ];
 
 module.exports = tests;

--- a/validate-if-numbered-tags-exist.js
+++ b/validate-if-numbered-tags-exist.js
@@ -1,0 +1,19 @@
+// Validate If Numbered Tags Exist
+
+function hasNumberedTags(str) {
+  var regex = /(\<0>([^<]*?)\<\/0>)/i;
+  return !!str.match(regex);
+};
+
+var result = { success: false };
+var source =  crowdin.source;
+var translation = crowdin.translation;
+
+if (!hasNumberedTags(source) && !hasNumberedTags(translation)) {
+  result.success = true;
+} else {
+  result.message = 'Under Editor Settings, make sure you have selected "Show" for the "HTML tags displaying" setting. You may currently have it set to "Auto".';
+  result.fixes = [];
+}
+
+return result;

--- a/validate-if-numbered-tags-exist.test.js
+++ b/validate-if-numbered-tags-exist.test.js
@@ -1,0 +1,16 @@
+const {
+  iterateThroughTests,
+  createQaCheckFunction
+}= require('./utils');
+
+const tests = require('./__fixtures/validate-if-numbered-tags-exist-test-objects');
+const qaCheck = createQaCheckFunction('./validate-if-numbered-tags-exist.js');
+
+describe('validate-if-numbered-tags-exist', () => {
+  it('qaCheck is a function', () => {
+    expect(typeof qaCheck).toBe(
+      'function'
+    );
+  });
+  iterateThroughTests(qaCheck, tests);
+});


### PR DESCRIPTION
Recently, we discovered that for QA checks, the source and translation submitted to the QA check function can differ depending on the user's editor settings for whether or not to display HTML tags or Crowdin's numbered tags. Our other custom QA check ("Validate Inline Code Blocks") assumed only code blocks were numbered tags (an oversight on my part).  We really need to check code blocks, so I removed the numbered tags from its regex and created this new QA check to make sure the user changes the editor settings, to warn them to change their settings if any numbered tags exist appear in the source or translation.

We probably should inform Crowdin of this issue as we think it would be much better if the source and translation used the HTML tags instead of the numbered tags.