### PR TITLE
fix(tools): Handle code block containing hasOwnProperty

### DIFF
--- a/__fixtures/validate-inline-code-blocks-test-objects.js
+++ b/__fixtures/validate-inline-code-blocks-test-objects.js
@@ -82,7 +82,28 @@ const tests = [
     result: {
       success: true
     }
-  } 
+  },
+  {
+    name: 'should pass when source and translation when code blocks have hasOwnProperty as a code block string ',
+    crowdin: {
+      source: `The first <code>hasOwnProperty</code> returns <code>true</code>, while the second returns <code>false</code>.`,
+      translation: `El primer <code>hasOwnProperty</code> devuelve <code>true</code>, mientras que el segundo devuelve <code>false</code>.`
+    },
+    result: {
+      success: true,
+    }
+  },
+  {
+    name: 'should fail when source contains hasOwnProperty as a code block string the translation does not ',
+    crowdin: {
+      source: `The first <code>hasOwnProperty</code> returns <code>true</code>, while the second returns <code>false</code>.`,
+      translation: `El primer <code>hasProperty</code> devuelve <code>true</code>, mientras que el segundo devuelve <code>false</code>.`
+    },
+    result: {
+      success: false,
+      message: 'Inline code blocks should not be changed. You appear to have changed at least one code block.'
+    }
+  }  
 ];
 
 module.exports = tests;

--- a/validate-inline-code-blocks.js
+++ b/validate-inline-code-blocks.js
@@ -10,9 +10,10 @@ function createCodeArr(arr) {
 
 function countElements(arr) {
   var obj = {};
+  obj.__tempHasOwnProperty = Object.hasOwnProperty;
   for (var i = 0; i < arr.length; i++) {
     var elem = arr[i];
-    if (obj[elem]) {
+    if (obj.__tempHasOwnProperty(elem)) {
       obj[elem]++;
     } else {
       obj[elem] = 1;

--- a/validate-inline-code-blocks.js
+++ b/validate-inline-code-blocks.js
@@ -10,7 +10,7 @@ function createCodeArr(arr) {
 
 function countElements(arr) {
   var obj = {};
-  obj.__tempHasOwnProperty = Object.hasOwnProperty;
+  obj.__tempHasOwnProperty = Object.prototype.hasOwnProperty;
   for (var i = 0; i < arr.length; i++) {
     var elem = arr[i];
     if (obj.__tempHasOwnProperty(elem)) {


### PR DESCRIPTION
This PR fixes an edge case for the `Validate Inline Code Blocks` custom QA check, where by chance one of the code blocks contains the string "hasOwnProperty".   I added a new test just for this edge case also.

You can run `npm run test` and everything should pass.